### PR TITLE
ParserResult should hold different group data

### DIFF
--- a/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
+++ b/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
@@ -192,7 +192,8 @@ public class TextParser implements ITextParser {
         ParserResult parserResult = new ParserResult();
         parserResult.setLines(this.blocks);
         extractGroupData(m);
-        parserResult.setGroupData(this.parsingAction.getGroupData());
+        Map<String, String> groupData = this.parsingAction.getGroupData();
+        parserResult.setGroupData(groupData == null ? null : new HashMap(groupData));
         int hashCode = this.blocks.toString().hashCode();
         Set<Integer> hashCodeSet = this.parsingAction.getHashCode();
 


### PR DESCRIPTION
It seems that ParserResults generated by the same ParserAction now hold the same groupData. This doesn't make sense; they should be different.