### PR TITLE
[COMPASS #46] [FOLLOWUP] fix: blockEnd should be set to null after parse.

### DIFF
--- a/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
+++ b/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
@@ -80,8 +80,9 @@ public class TextParser implements ITextParser {
     @Override
     public void parse(String line) {
         // 若blockEnd不为null，则需要首先处理上一次匹配的末尾行
-        if (blockEnd != null) {
-            parseInternal(blockEnd);
+        if (this.blockEnd != null) {
+            parseInternal(this.blockEnd);
+            this.blockEnd = null;
         }
         parseInternal(line);
     }


### PR DESCRIPTION
`blockEnd`should be set to null after parsed.