### PR TITLE
[WIP] make parser module independent with springboot framework.

### DIFF
--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
@@ -16,8 +16,14 @@
 
 package com.oppo.cloud.parser.service.job.parser;
 
+import com.oppo.cloud.common.util.spring.SpringBeanUtil;
+import com.oppo.cloud.parser.config.CustomConfig;
+import com.oppo.cloud.parser.config.ThreadPoolConfig;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.service.job.oneclick.IProgressListener;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.List;
 
 
 public class ParserFactory {
@@ -39,7 +45,9 @@ public class ParserFactory {
                 return sparkEventLogParser;
 
             case SPARK_EXECUTOR:
-                SparkExecutorLogParser sparkExecutorLogParser = new SparkExecutorLogParser(parserParam);
+                ThreadPoolTaskExecutor parserThreadPool = (ThreadPoolTaskExecutor) SpringBeanUtil.getBean(ThreadPoolConfig.PARSER_THREAD_POOL);
+                List<String> jvmTypeList = (List<String>) SpringBeanUtil.getBean(CustomConfig.GC_CONFIG);
+                SparkExecutorLogParser sparkExecutorLogParser = new SparkExecutorLogParser(parserParam, parserThreadPool, jvmTypeList);
                 sparkExecutorLogParser.addListener(listener);
                 return sparkExecutorLogParser;
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
@@ -21,13 +21,10 @@ import com.oppo.cloud.common.constant.ProgressState;
 import com.oppo.cloud.common.domain.job.LogPath;
 import com.oppo.cloud.common.domain.oneclick.OneClickProgress;
 import com.oppo.cloud.common.domain.oneclick.ProgressInfo;
-import com.oppo.cloud.common.util.spring.SpringBeanUtil;
 import com.oppo.cloud.common.util.textparser.ParserAction;
 import com.oppo.cloud.common.util.textparser.ParserManager;
 import com.oppo.cloud.common.util.textparser.TextParser;
-import com.oppo.cloud.parser.config.CustomConfig;
 import com.oppo.cloud.parser.config.DiagnosisConfig;
-import com.oppo.cloud.parser.config.ThreadPoolConfig;
 import com.oppo.cloud.parser.domain.job.CommonResult;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.domain.job.SparkExecutorLogParserResult;
@@ -59,12 +56,13 @@ public class SparkExecutorLogParser extends CommonTextParser implements IParser 
 
     private final List<String> jvmTypeList;
 
-    public SparkExecutorLogParser(ParserParam param) {
+    public SparkExecutorLogParser(ParserParam param,
+                                  ThreadPoolTaskExecutor threadPool,
+                                  List<String> jvmTypeList) {
         this.param = param;
         this.isOneClick = param.getLogRecord().getIsOneClick();
-        parserThreadPool = (ThreadPoolTaskExecutor) SpringBeanUtil.getBean(ThreadPoolConfig.PARSER_THREAD_POOL);
-        jvmTypeList = (List<String>) SpringBeanUtil.getBean(CustomConfig.GC_CONFIG);
-
+        this.parserThreadPool = threadPool;
+        this.jvmTypeList = jvmTypeList;
     }
 
     public CommonResult run() {

--- a/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParserTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParserTest.java
@@ -19,11 +19,15 @@ package com.oppo.cloud.parser.service.job.parser;
 import com.oppo.cloud.common.constant.LogType;
 import com.oppo.cloud.common.domain.job.LogPath;
 import com.oppo.cloud.common.domain.job.LogRecord;
+import com.oppo.cloud.common.util.spring.SpringBeanUtil;
+import com.oppo.cloud.parser.config.CustomConfig;
+import com.oppo.cloud.parser.config.ThreadPoolConfig;
 import com.oppo.cloud.parser.domain.job.CommonResult;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.service.ParamUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.List;
 import java.util.Map;
@@ -42,7 +46,11 @@ class SparkExecutorLogParserTest {
                 logPathMap.get(LogType.SPARK_EXECUTOR.getName())
         );
 
-        SparkExecutorLogParser parser = new SparkExecutorLogParser(param);
+        ThreadPoolTaskExecutor parserThreadPool = (ThreadPoolTaskExecutor)
+                SpringBeanUtil.getBean(ThreadPoolConfig.PARSER_THREAD_POOL);
+        List<String> jvmTypeList = (List<String>) SpringBeanUtil.getBean(CustomConfig.GC_CONFIG);
+
+        SparkExecutorLogParser parser = new SparkExecutorLogParser(param, parserThreadPool, jvmTypeList);
         CommonResult commonResult = parser.run();
         System.out.println(commonResult);
     }


### PR DESCRIPTION
For now, the parser module couples the basic capability of abormnal log parsing with the Service layer that handles user requests.

This is unfriendly for other platforms to integrate the abormal log parsing capability of Compass. 

Therefore, it is necessary to decouple the core capability of the parser module from the spring boot framework and finally form an independent parser-core module.