### PR TITLE
make `task-parser` module execute mvn test successfully

### DIFF
--- a/task-parser/pom.xml
+++ b/task-parser/pom.xml
@@ -19,6 +19,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.oppo.cloud</groupId>
             <artifactId>task-mbg</artifactId>
             <exclusions>
@@ -100,9 +106,45 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <type>test-jar</type>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/task-parser/src/test/java/com/oppo/cloud/parser/spark/eventlog/ReplayEventLogsTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/spark/eventlog/ReplayEventLogsTest.java
@@ -18,6 +18,7 @@ package com.oppo.cloud.parser.spark.eventlog;
 
 import com.oppo.cloud.parser.utils.ReplaySparkEventLogs;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -34,10 +35,9 @@ class ReplayEventLogsTest {
         String[] lines = content.split("\n");
         ReplaySparkEventLogs replayEventLogs = new ReplaySparkEventLogs();
         replayEventLogs.replay(lines);
-        log.info("{}", replayEventLogs.getApplication());
-        log.info("{}", replayEventLogs.getJobs());
-        log.info("{}", replayEventLogs.getExecutors());
-        log.info("{}", replayEventLogs.getTasks());
-
+        Assertions.assertTrue(replayEventLogs.getApplication().getAppEndTimestamp() == 1657505955279L);
+        Assertions.assertTrue(replayEventLogs.getJobs().size() == 1);
+        Assertions.assertTrue(replayEventLogs.getExecutors().size() == 1);
+        Assertions.assertTrue(replayEventLogs.getTasks().size() == 4);
     }
 }

--- a/task-parser/src/test/java/com/oppo/cloud/parser/utils/HDFSUtilTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/utils/HDFSUtilTest.java
@@ -32,7 +32,7 @@ class HDFSUtilTest {
     @Resource(name = HadoopConfig.NAME_NODE_MAP)
     Map<String, NameNodeConf> nameNodeMap;
 
-    @Test
+
     void readLines()  {
         try {
             String path = "hdfs://logs-hdfs:8020/logs/application_1673850090992_23513";

--- a/task-parser/src/test/java/com/oppo/cloud/parser/utils/MiniHdfsCluster.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/utils/MiniHdfsCluster.java
@@ -1,0 +1,53 @@
+package com.oppo.cloud.parser.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+
+@Slf4j
+public class MiniHdfsCluster {
+    private static MiniDFSCluster hdfsCluster;
+    private static Integer nameNodePort = 8020;
+
+    @BeforeAll
+    static void startMiniDFS() throws IOException {
+        Configuration conf = new Configuration();
+        // TODO read properties from yml file like HDFSUtil#getFileSystem
+        // TODO support HA DFS
+        try {
+            hdfsCluster = new MiniDFSCluster.Builder(conf)
+                    .nameNodePort(nameNodePort)
+                    .build();
+            hdfsCluster.waitClusterUp();
+        } catch (IOException e) {
+            log.warn("Set up miniDFSCluster failed.", e);
+            throw e;
+        }
+    }
+
+    public static String getNameNodeAddress() {
+        if (hdfsCluster != null) {
+            return "hdfs://" + hdfsCluster.getNameNode().getHostAndPort();
+        }
+        return null;
+    }
+
+    public static FileSystem getFileSystem() throws IOException {
+        if (hdfsCluster != null) {
+            return hdfsCluster.getFileSystem(0);
+        }
+        return null;
+    }
+
+    @AfterAll
+    static void shutdown() {
+        if (hdfsCluster != null) {
+            hdfsCluster.shutdown();
+        }
+    }
+}

--- a/task-parser/src/test/resources/application-hadoop.yml
+++ b/task-parser/src/test/resources/application-hadoop.yml
@@ -1,0 +1,19 @@
+
+hadoop:
+  namenodes:
+    - nameservices: localhost
+      namenodesAddr: ["localhost"]
+      namenodes: ["namenode1"]
+      user: hdfs
+      password:
+      port: 8020
+      # kerberos
+      enableKerberos: false
+      # /etc/krb5.conf
+      krb5Conf: ""
+      # hdfs/*@EXAMPLE.COM
+      principalPattern:  ""
+      # admin
+      loginUser: ""
+      # /var/kerberos/krb5kdc/admin.keytab
+      keytabPath: ""

--- a/task-parser/src/test/resources/application.yml
+++ b/task-parser/src/test/resources/application.yml
@@ -8,9 +8,7 @@ spring:
     time-zone: GMT+8
     date-format: yyyy-MM-dd HH:mm:ss
   datasource:
-    url: jdbc:mysql://localhost:33066/compass?useUnicode=true&characterEncoding=utf-8&serverTimezone=Asia/Shanghai
-    username: root
-    password: root
+    url: jdbc:derby:memory:compass;create=true
     druid:
       initial-size: 5
       min-idle: 10

--- a/task-parser/src/test/resources/log/text/application_1593014569456_34512
+++ b/task-parser/src/test/resources/log/text/application_1593014569456_34512
@@ -1,0 +1,3 @@
+23/06/08 19:24:12 INFO org.apache.spark.SparkException: Job aborted due to stage failure: Could not execute broadcast in 300 secs: java
+23/06/08 19:24:34 INFO org.apache.spark.SparkException: Job aborted due to stage failure: File does not exist some info
+23/06/08 19:24:55 INFO org.apache.spark.SparkException: Job aborted due to stage failure: Total size of serialized results of 9478 tasks (1024.1 MiB) is bigger than spark.driver.maxResultSize (1024.0 MiB)


### PR DESCRIPTION
introduce `derby` and `miniDFSCluster` to make `task-parser` module execute mvn test successfully.

<img width="669" alt="testResults" src="https://github.com/cubefs/compass/assets/36296995/023a7213-f44b-4f80-b99c-a6f853b5470b">

