### PR TITLE
improve `task-parser` test.

### DIFF
--- a/task-parser/src/test/java/com/oppo/cloud/parser/service/job/reader/HDFSReaderTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/service/job/reader/HDFSReaderTest.java
@@ -20,6 +20,7 @@ import com.oppo.cloud.common.constant.ProtocolType;
 import com.oppo.cloud.common.domain.job.LogPath;
 import com.oppo.cloud.parser.service.reader.HDFSReader;
 import com.oppo.cloud.parser.utils.MiniHdfsCluster;
+import com.oppo.cloud.parser.utils.ResourcePreparer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -36,27 +37,9 @@ import java.util.List;
 
 @SpringBootTest
 @Slf4j
-class HDFSReaderTest extends MiniHdfsCluster {
-    private static String LOCAL_TEXT_LOG_DIR = "/log/text/";
-    private static String HDFS_TEXT_LOG_DIR = "/logs";
+class HDFSReaderTest extends ResourcePreparer {
+
     private static String PROTOCAL_TYPE = ProtocolType.HDFS.getName();
-
-    @BeforeAll
-    static void prepareResources() throws IOException {
-        final URL resourcesDir = HDFSReaderTest.class.getResource(LOCAL_TEXT_LOG_DIR);
-        final FileSystem fs = getFileSystem();
-        if (fs != null) {
-            fs.mkdirs(new Path(HDFS_TEXT_LOG_DIR));
-            fs.copyFromLocalFile(new Path(resourcesDir.getPath()), new Path(HDFS_TEXT_LOG_DIR));
-        } else {
-            log.error("Got filesystem is null, maybe miniDFSCluster is not ready.");
-            throw new IOException("Get FileSystem failed.");
-        }
-    }
-
-    private String getTextLogDir() {
-        return getNameNodeAddress() + HDFS_TEXT_LOG_DIR;
-    }
 
     @Test
     void listFiles() throws Exception {

--- a/task-parser/src/test/java/com/oppo/cloud/parser/utils/HDFSUtilTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/utils/HDFSUtilTest.java
@@ -17,25 +17,36 @@
 package com.oppo.cloud.parser.utils;
 
 import com.oppo.cloud.common.domain.cluster.hadoop.NameNodeConf;
+import com.oppo.cloud.common.domain.job.LogPath;
 import com.oppo.cloud.parser.config.HadoopConfig;
 import com.oppo.cloud.parser.domain.reader.ReaderObject;
+import com.oppo.cloud.parser.service.reader.HDFSReader;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.annotation.Resource;
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
-
 @SpringBootTest
-class HDFSUtilTest {
+class HDFSUtilTest extends ResourcePreparer {
 
     @Resource(name = HadoopConfig.NAME_NODE_MAP)
     Map<String, NameNodeConf> nameNodeMap;
 
-
-    void readLines()  {
-        try {
-            String path = "hdfs://logs-hdfs:8020/logs/application_1673850090992_23513";
+    @Test
+    void readLines() throws Exception {
+        String logDir = getTextLogDir();
+        RemoteIterator<LocatedFileStatus> files = getFileSystem().listFiles(new Path(logDir), true);
+        Assertions.assertTrue(files.hasNext());
+        while (files.hasNext()) {
+            String path = files.next().getPath().toString();
             NameNodeConf nameNode = HDFSUtil.getNameNode(nameNodeMap, path);
             ReaderObject readerObject = HDFSUtil.getReaderObject(nameNode, path);
             while (true) {
@@ -43,11 +54,8 @@ class HDFSUtilTest {
                 if (line == null) {
                     break;
                 }
-                System.out.println(line);
+                Assertions.assertTrue(!line.isEmpty());
             }
-        } catch (Exception e) {
-           e.printStackTrace();
         }
     }
-
 }

--- a/task-parser/src/test/java/com/oppo/cloud/parser/utils/ResourcePreparer.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/utils/ResourcePreparer.java
@@ -1,0 +1,32 @@
+package com.oppo.cloud.parser.utils;
+
+import com.oppo.cloud.common.constant.ProtocolType;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Slf4j
+public class ResourcePreparer extends MiniHdfsCluster {
+    private static String LOCAL_TEXT_LOG_DIR = "/log/text/";
+    private static String HDFS_TEXT_LOG_DIR = "/logs";
+    @BeforeAll
+    static void prepareResources() throws IOException {
+        final URL resourcesDir = ResourcePreparer.class.getResource(LOCAL_TEXT_LOG_DIR);
+        final FileSystem fs = getFileSystem();
+        if (fs != null) {
+            fs.mkdirs(new Path(HDFS_TEXT_LOG_DIR));
+            fs.copyFromLocalFile(new Path(resourcesDir.getPath()), new Path(HDFS_TEXT_LOG_DIR));
+        } else {
+            log.error("Got filesystem is null, maybe miniDFSCluster is not ready.");
+            throw new IOException("Get FileSystem failed.");
+        }
+    }
+
+    public String getTextLogDir() {
+        return getNameNodeAddress() + HDFS_TEXT_LOG_DIR;
+    }
+}


### PR DESCRIPTION
1. Improve `HDFSUtilTest`.
2. Move text log preparing in `ResourcePreparer` and all HDFS related tests can reuse this logical, like `HDFSUtilTest`.
3. All tests in `task-parser` passed.
<img width="601" alt="截屏2023-09-23 09 39 50" src="https://github.com/cubefs/compass/assets/36296995/d629f497-8837-4f67-a590-84e28310bf4d">
