### PR TITLE
fix text parsing return nothing when the error logs are the last lines.

### DIFF
--- a/task-common/src/main/java/com/oppo/cloud/common/util/textparser/ITextParser.java
+++ b/task-common/src/main/java/com/oppo/cloud/common/util/textparser/ITextParser.java
@@ -32,4 +32,9 @@ public interface ITextParser {
      * Get the result
      */
     Map<String, ParserAction> getResults();
+
+    /**
+     * Close the text parser
+     */
+    void close();
 }

--- a/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
+++ b/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
@@ -103,6 +103,16 @@ public class TextParser implements ITextParser {
         }
     }
 
+    @Override
+    public void close() {
+        // if position state is middle, means the text parser is parsing.
+        // we should set current parse results when paring the last line,
+        // or nothing will be parsed.
+        if (PositionState.MIDDLE.equals(this.state)) {
+            setParserResults(null);
+        }
+    }
+
     /**
      * Get parsing results
      */

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
@@ -160,6 +160,7 @@ public class SparkExecutorLogParser extends CommonTextParser implements IParser 
                 break;
             }
             if (line == null) {
+                headTextParser.close();
                 break;
             }
             headTextParser.parse(line);


### PR DESCRIPTION
When the error logs are at the end of the log file, even if these logs comply with the matching rules, there will be no new lines to trigger the `setParserResults`, causing parseResults to be empty, which is not as expected.