### PR TITLE
[PARSER] Refacotr parser factory to make it easier to understand.

### DIFF
--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/oneclick/ParserListenerBus.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/oneclick/ParserListenerBus.java
@@ -21,7 +21,7 @@ import com.oppo.cloud.common.domain.oneclick.OneClickProgress;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class OneClickSubject {
+public abstract class ParserListenerBus {
 
     private List<IProgressListener> listenerList = new ArrayList<>();
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/CommonTextParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/CommonTextParser.java
@@ -18,15 +18,14 @@ package com.oppo.cloud.parser.service.job.parser;
 
 import com.oppo.cloud.common.util.textparser.*;
 import com.oppo.cloud.parser.domain.reader.ReaderObject;
-import com.oppo.cloud.parser.service.job.oneclick.OneClickSubject;
+import com.oppo.cloud.parser.service.job.oneclick.ParserListenerBus;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.util.*;
 
 @Slf4j
-public abstract class CommonTextParser extends OneClickSubject {
+public abstract class CommonTextParser extends IParser {
 
     private ReaderObject readerObject;
     private List<ParserAction> actions;

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/IParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/IParser.java
@@ -17,9 +17,12 @@
 package com.oppo.cloud.parser.service.job.parser;
 
 import com.oppo.cloud.parser.domain.job.CommonResult;
+import com.oppo.cloud.parser.service.job.oneclick.ParserListenerBus;
 
-public interface IParser {
+public abstract class IParser extends ParserListenerBus {
 
-    CommonResult run();
+    public CommonResult run() {
+        return null;
+    }
 
 }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceContainerLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceContainerLogParser.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class MapReduceContainerLogParser extends CommonTextParser implements IParser{
+public class MapReduceContainerLogParser extends CommonTextParser {
 
     private final ParserParam param;
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceJobHistoryParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceJobHistoryParser.java
@@ -31,7 +31,7 @@ import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.domain.mr.MRAppInfo;
 import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.service.job.detector.DetectorManager;
-import com.oppo.cloud.parser.service.job.oneclick.OneClickSubject;
+import com.oppo.cloud.parser.service.job.oneclick.ParserListenerBus;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
 import com.oppo.cloud.parser.service.rules.JobRulesConfigService;
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class MapReduceJobHistoryParser extends OneClickSubject implements IParser {
+public class MapReduceJobHistoryParser extends IParser {
 
     private final ParserParam param;
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
@@ -32,34 +32,33 @@ public class ParserFactory {
      * create parser
      */
     public static IParser create(ParserParam parserParam, IProgressListener listener) {
+        IParser parser = createParserInternal(parserParam, listener);
+        if (parser != null) {
+            parser.addListener(listener);
+        }
+        return parser;
+    }
+
+    private static IParser createParserInternal(ParserParam parserParam, IProgressListener listener) {
         switch (parserParam.getLogType()) {
 
             case SCHEDULER:
-                SchedulerLogParser schedulerLogParser = new SchedulerLogParser(parserParam);
-                schedulerLogParser.addListener(listener);
-                return schedulerLogParser;
+                return new SchedulerLogParser(parserParam);
 
             case SPARK_EVENT:
-                SparkEventLogParser sparkEventLogParser = new SparkEventLogParser(parserParam);
-                sparkEventLogParser.addListener(listener);
-                return sparkEventLogParser;
+                return new SparkEventLogParser(parserParam);
 
             case SPARK_EXECUTOR:
                 ThreadPoolTaskExecutor parserThreadPool = (ThreadPoolTaskExecutor) SpringBeanUtil.getBean(ThreadPoolConfig.PARSER_THREAD_POOL);
                 List<String> jvmTypeList = (List<String>) SpringBeanUtil.getBean(CustomConfig.GC_CONFIG);
                 SparkExecutorLogParser sparkExecutorLogParser = new SparkExecutorLogParser(parserParam, parserThreadPool, jvmTypeList);
-                sparkExecutorLogParser.addListener(listener);
                 return sparkExecutorLogParser;
 
             case MAPREDUCE_JOB_HISTORY:
-                MapReduceJobHistoryParser mapReduceJobHistoryParser = new MapReduceJobHistoryParser(parserParam);
-                mapReduceJobHistoryParser.addListener(listener);
-                return mapReduceJobHistoryParser;
+                return new MapReduceJobHistoryParser(parserParam);
 
             case MAPREDUCE_CONTAINER:
-                MapReduceContainerLogParser mapReduceContainerLogParser = new MapReduceContainerLogParser(parserParam);
-                mapReduceContainerLogParser.addListener(listener);
-                return mapReduceContainerLogParser;
+                return new MapReduceContainerLogParser(parserParam);
 
             default:
                 return null;

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SchedulerLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SchedulerLogParser.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class SchedulerLogParser extends CommonTextParser implements IParser {
+public class SchedulerLogParser extends CommonTextParser {
 
     private final ParserParam param;
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkEventLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkEventLogParser.java
@@ -30,7 +30,6 @@ import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.domain.spark.eventlog.SparkApplication;
 import com.oppo.cloud.parser.domain.spark.eventlog.SparkExecutor;
 import com.oppo.cloud.parser.service.job.detector.DetectorManager;
-import com.oppo.cloud.parser.service.job.oneclick.OneClickSubject;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
 import com.oppo.cloud.parser.service.rules.JobRulesConfigService;
@@ -42,7 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
-public class SparkEventLogParser extends OneClickSubject implements IParser {
+public class SparkEventLogParser extends IParser {
 
     private final ParserParam param;
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
@@ -46,7 +46,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
 @Slf4j
-public class SparkExecutorLogParser extends CommonTextParser implements IParser {
+public class SparkExecutorLogParser extends CommonTextParser {
 
     private final ParserParam param;
 


### PR DESCRIPTION
There was some repeated logic in the original parserFactory. I refactored it to avoid these repeated codes, and the class OneClickSubject was renamed ParserListenerBus to make it easier to understand the multiple abstractions of parser. (ps: According to my understanding, OneClickSubject is more like a `Listener Bus`, and the original name is difficult to understand)