### PR TITLE
[PARSER] Remove spring related code from the parsers.

### DIFF
--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceContainerLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceContainerLogParser.java
@@ -41,12 +41,10 @@ public class MapReduceContainerLogParser extends CommonTextParser {
 
     private boolean isOneClick;
 
-
     public MapReduceContainerLogParser(ParserParam param) {
         this.param = param;
         this.isOneClick = param.getLogRecord().getIsOneClick();
     }
-
 
     @Override
     public CommonResult run() {
@@ -87,7 +85,6 @@ public class MapReduceContainerLogParser extends CommonTextParser {
         updateParserProgress(ProgressState.SUCCEED, 0, 0);
         return commonResult;
     }
-
 
     public void updateParserProgress(ProgressState state, Integer progress, Integer count) {
         if (!this.isOneClick) {

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceJobHistoryParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceJobHistoryParser.java
@@ -24,17 +24,14 @@ import com.oppo.cloud.common.domain.job.LogPath;
 import com.oppo.cloud.common.domain.mr.config.MREnvironmentConfig;
 import com.oppo.cloud.common.domain.oneclick.OneClickProgress;
 import com.oppo.cloud.common.domain.oneclick.ProgressInfo;
-import com.oppo.cloud.common.util.spring.SpringBeanUtil;
 import com.oppo.cloud.parser.domain.job.CommonResult;
 import com.oppo.cloud.parser.domain.job.DetectorParam;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.domain.mr.MRAppInfo;
 import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.service.job.detector.DetectorManager;
-import com.oppo.cloud.parser.service.job.oneclick.ParserListenerBus;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
-import com.oppo.cloud.parser.service.rules.JobRulesConfigService;
 import com.oppo.cloud.parser.utils.JobHistoryUtil;
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,11 +48,9 @@ public class MapReduceJobHistoryParser extends IParser {
 
     private boolean isOneClick;
 
-
-    public MapReduceJobHistoryParser(ParserParam param) {
+    public MapReduceJobHistoryParser(ParserParam param, DetectorConfig config) {
         this.param = param;
-        JobRulesConfigService jobRulesConfigService = (JobRulesConfigService) SpringBeanUtil.getBean(JobRulesConfigService.class);
-        this.config = jobRulesConfigService.detectorConfig;
+        this.config = config;
         this.isOneClick = param.getLogRecord().getIsOneClick();
     }
 
@@ -100,7 +95,6 @@ public class MapReduceJobHistoryParser extends IParser {
         }
         return detect(mrAppInfo);
     }
-
 
     private CommonResult detect(MRAppInfo mrAppInfo) {
 

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
@@ -16,11 +16,13 @@
 
 package com.oppo.cloud.parser.service.job.parser;
 
+import com.oppo.cloud.common.domain.eventlog.config.DetectorConfig;
 import com.oppo.cloud.common.util.spring.SpringBeanUtil;
 import com.oppo.cloud.parser.config.CustomConfig;
 import com.oppo.cloud.parser.config.ThreadPoolConfig;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.service.job.oneclick.IProgressListener;
+import com.oppo.cloud.parser.service.rules.JobRulesConfigService;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.List;
@@ -46,7 +48,7 @@ public class ParserFactory {
                 return new SchedulerLogParser(parserParam);
 
             case SPARK_EVENT:
-                return new SparkEventLogParser(parserParam);
+                return new SparkEventLogParser(parserParam, getDetectorConf());
 
             case SPARK_EXECUTOR:
                 ThreadPoolTaskExecutor parserThreadPool = (ThreadPoolTaskExecutor) SpringBeanUtil.getBean(ThreadPoolConfig.PARSER_THREAD_POOL);
@@ -55,7 +57,7 @@ public class ParserFactory {
                 return sparkExecutorLogParser;
 
             case MAPREDUCE_JOB_HISTORY:
-                return new MapReduceJobHistoryParser(parserParam);
+                return new MapReduceJobHistoryParser(parserParam, getDetectorConf());
 
             case MAPREDUCE_CONTAINER:
                 return new MapReduceContainerLogParser(parserParam);
@@ -63,5 +65,10 @@ public class ParserFactory {
             default:
                 return null;
         }
+    }
+
+    private static DetectorConfig getDetectorConf() {
+        JobRulesConfigService jobRulesConfigService = (JobRulesConfigService) SpringBeanUtil.getBean(JobRulesConfigService.class);
+        return jobRulesConfigService.detectorConfig;
     }
 }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkEventLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkEventLogParser.java
@@ -24,7 +24,6 @@ import com.oppo.cloud.common.domain.eventlog.config.SparkEnvironmentConfig;
 import com.oppo.cloud.common.domain.job.LogPath;
 import com.oppo.cloud.common.domain.oneclick.OneClickProgress;
 import com.oppo.cloud.common.domain.oneclick.ProgressInfo;
-import com.oppo.cloud.common.util.spring.SpringBeanUtil;
 import com.oppo.cloud.parser.domain.job.*;
 import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.domain.spark.eventlog.SparkApplication;
@@ -32,7 +31,6 @@ import com.oppo.cloud.parser.domain.spark.eventlog.SparkExecutor;
 import com.oppo.cloud.parser.service.job.detector.DetectorManager;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
-import com.oppo.cloud.parser.service.rules.JobRulesConfigService;
 import com.oppo.cloud.parser.utils.ReplaySparkEventLogs;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,10 +47,9 @@ public class SparkEventLogParser extends IParser {
 
     private boolean isOneClick;
 
-    public SparkEventLogParser(ParserParam param) {
+    public SparkEventLogParser(ParserParam param, DetectorConfig config) {
         this.param = param;
-        JobRulesConfigService jobRulesConfigService = (JobRulesConfigService) SpringBeanUtil.getBean(JobRulesConfigService.class);
-        this.config = jobRulesConfigService.detectorConfig;
+        this.config = config;
         this.isOneClick = param.getLogRecord().getIsOneClick();
     }
 


### PR DESCRIPTION
As some spring-related code in the parser's code, when should remove them.
After remove all spring-related code in parsers, we can move parser's code to a new module, and make the parser easier to integrate into other platforms.