### PR TITLE
fix: add close for CommonTextParser

### DIFF
--- a/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
+++ b/task-common/src/main/java/com/oppo/cloud/common/util/textparser/TextParser.java
@@ -245,7 +245,9 @@ public class TextParser implements ITextParser {
 
     private void extractGroupData(Matcher m) {
         // 尾行当标志位，不参与提取
-        if (this.parsingAction.getGroupNames() != null && this.state != PositionState.TAIL) {
+        if (m != null &&
+                this.parsingAction.getGroupNames() != null &&
+                this.state != PositionState.TAIL) {
             Map<String, String> groupMap = this.parsingAction.getGroupData();
             if (groupMap == null) {
                 groupMap = new HashMap<>();

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/CommonTextParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/CommonTextParser.java
@@ -54,6 +54,7 @@ public abstract class CommonTextParser extends IParser {
                 break;
             }
             if (line == null) {
+                headTextParser.close();
                 break;
             }
             headTextParser.parse(line);


### PR DESCRIPTION
CommonTextParser also need close and `extractGroupData` should check matcher is `null` or not.