### PR TITLE
feat: multiple writer support for log parsers

### DIFF
--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/CommonTextParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/CommonTextParser.java
@@ -19,6 +19,7 @@ package com.oppo.cloud.parser.service.job.parser;
 import com.oppo.cloud.common.util.textparser.*;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.domain.reader.ReaderObject;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.BufferedReader;
@@ -30,9 +31,14 @@ public abstract class CommonTextParser extends IParser {
     private ReaderObject readerObject;
     private List<ParserAction> actions;
 
-    public CommonTextParser(ParserParam param, List<ParserAction> actions) {
+    private ParserResultSink parserResultSink;
+
+    public CommonTextParser(ParserParam param,
+                            List<ParserAction> actions,
+                            ParserResultSink parserResultSink) {
         super(param);
         this.actions = actions;
+        this.parserResultSink = parserResultSink;
     }
 
     public Map<String, ParserAction> parse(ReaderObject readerObject) throws Exception {
@@ -66,6 +72,11 @@ public abstract class CommonTextParser extends IParser {
     }
 
     public List<ParserAction> getActions() {
-        return actions;
+        return this.actions;
     }
+
+    public ParserResultSink getSink() {
+        return this.parserResultSink;
+    }
+
 }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/IParserFactory.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/IParserFactory.java
@@ -21,6 +21,7 @@ import com.oppo.cloud.common.domain.eventlog.config.DetectorConfig;
 import com.oppo.cloud.common.util.textparser.ParserAction;
 import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.service.job.oneclick.IProgressListener;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -34,6 +35,8 @@ public interface IParserFactory {
     Executor getTaskExecutor();
 
     List<String> getJvmList();
+
+    ParserResultSink getParserResultSink();
 
     /**
      * create parser
@@ -51,20 +54,20 @@ public interface IParserFactory {
         switch (logType) {
 
             case SCHEDULER:
-                return new SchedulerLogParser(parserParam, getParserActions(logType));
+                return new SchedulerLogParser(parserParam, getParserActions(logType), getParserResultSink());
 
             case SPARK_EVENT:
                 return new SparkEventLogParser(parserParam, getDetectorConf());
 
             case SPARK_EXECUTOR:
-                return new SparkExecutorLogParser(parserParam, getParserActions(logType),
+                return new SparkExecutorLogParser(parserParam, getParserActions(logType), getParserResultSink(),
                         getTaskExecutor(), getJvmList());
 
             case MAPREDUCE_JOB_HISTORY:
                 return new MapReduceJobHistoryParser(parserParam, getDetectorConf());
 
             case MAPREDUCE_CONTAINER:
-                return new MapReduceContainerLogParser(parserParam, getParserActions(logType));
+                return new MapReduceContainerLogParser(parserParam, getParserActions(logType), getParserResultSink());
 
             default:
                 return null;

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceContainerLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/MapReduceContainerLogParser.java
@@ -25,6 +25,7 @@ import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
 import com.oppo.cloud.parser.service.writer.OpenSearchWriter;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -35,8 +36,9 @@ import java.util.Map;
 public class MapReduceContainerLogParser extends CommonTextParser {
 
     public MapReduceContainerLogParser(ParserParam param,
-                                       List<ParserAction> actions) {
-        super(param, actions);
+                                       List<ParserAction> actions,
+                                       ParserResultSink parserResultSink) {
+        super(param, actions, parserResultSink);
     }
 
     @Override
@@ -67,8 +69,8 @@ public class MapReduceContainerLogParser extends CommonTextParser {
                 } finally {
                     readerObject.close();
                 }
-                List<String> list = OpenSearchWriter.getInstance()
-                        .saveParserActions(logType, readerObject.getLogPath(), this.param, results);
+                List<String> list = getSink().saveParserActions(
+                        logType, readerObject.getLogPath(), this.param, results);
                 categories.addAll(list);
             }
         }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/ParserFactory.java
@@ -24,6 +24,8 @@ import com.oppo.cloud.parser.config.CustomConfig;
 import com.oppo.cloud.parser.config.DiagnosisConfig;
 import com.oppo.cloud.parser.config.ThreadPoolConfig;
 import com.oppo.cloud.parser.service.rules.JobRulesConfigService;
+import com.oppo.cloud.parser.service.writer.OpenSearchWriter;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -50,6 +52,14 @@ public class ParserFactory implements IParserFactory {
     @Override
     public List<String> getJvmList() {
         return (List<String>) SpringBeanUtil.getBean(CustomConfig.GC_CONFIG);
+    }
+
+    @Override
+    public ParserResultSink getParserResultSink() {
+        // TODO implement more kinds of writers and let them configurable.
+        ParserResultSink parserResultSink = new ParserResultSink();
+        parserResultSink.register(OpenSearchWriter.getInstance());
+        return parserResultSink;
     }
 
 }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SchedulerLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SchedulerLogParser.java
@@ -25,6 +25,7 @@ import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
 import com.oppo.cloud.parser.service.writer.OpenSearchWriter;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -35,8 +36,9 @@ import java.util.Map;
 public class SchedulerLogParser extends CommonTextParser {
 
     public SchedulerLogParser(ParserParam param,
-                              List<ParserAction> actions) {
-        super(param, actions);
+                              List<ParserAction> actions,
+                              ParserResultSink parserResultSink) {
+        super(param, actions, parserResultSink);
     }
 
     @Override
@@ -67,8 +69,8 @@ public class SchedulerLogParser extends CommonTextParser {
                 } finally {
                     readerObject.close();
                 }
-                List<String> list = OpenSearchWriter.getInstance()
-                        .saveParserActions(logType, readerObject.getLogPath(), this.param, results);
+                List<String> list = getSink().saveParserActions(
+                        logType, readerObject.getLogPath(), this.param, results);
                 categories.addAll(list);
             }
         }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParser.java
@@ -29,6 +29,7 @@ import com.oppo.cloud.parser.domain.reader.ReaderObject;
 import com.oppo.cloud.parser.service.reader.IReader;
 import com.oppo.cloud.parser.service.reader.LogReaderFactory;
 import com.oppo.cloud.parser.service.writer.OpenSearchWriter;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 import com.oppo.cloud.parser.utils.GCReportUtil;
 import lombok.extern.slf4j.Slf4j;
 
@@ -50,9 +51,10 @@ public class SparkExecutorLogParser extends CommonTextParser {
 
     public SparkExecutorLogParser(ParserParam param,
                                   List<ParserAction> actions,
+                                  ParserResultSink parserResultSink,
                                   Executor threadPool,
                                   List<String> jvmTypeList) {
-        super(param, actions);
+        super(param, actions, parserResultSink);
         this.parserThreadPool = threadPool;
         this.jvmTypeList = jvmTypeList;
     }
@@ -118,13 +120,12 @@ public class SparkExecutorLogParser extends CommonTextParser {
             readerObject.close();
         }
         if (result != null && result.getActionMap() != null) {
-            List<String> categories = OpenSearchWriter.getInstance()
-                    .saveParserActions(logType, readerObject.getLogPath(), this.param, result.getActionMap());
+            List<String> categories = getSink().saveParserActions(
+                    logType, readerObject.getLogPath(), this.param, result.getActionMap());
             result.setCategories(categories);
         }
         return result;
     }
-
 
     private SparkExecutorLogParserResult parseAction(String logType, ReaderObject readerObject) throws Exception {
         SparkExecutorLogParserResult result = parseRootAction(logType, readerObject);

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/job/task/YarnTask.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/job/task/YarnTask.java
@@ -26,6 +26,7 @@ import com.oppo.cloud.parser.domain.job.ParserParam;
 import com.oppo.cloud.parser.domain.job.TaskParam;
 import com.oppo.cloud.parser.domain.job.TaskResult;
 import com.oppo.cloud.parser.service.writer.OpenSearchWriter;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -72,8 +73,10 @@ public class YarnTask extends Task {
         ParserParam param = new ParserParam(LogType.YARN.getName(), this.taskParam.getLogRecord(),
                 this.taskParam.getApp(), null);
 
-        List<String> list = OpenSearchWriter.getInstance()
-                .saveParserActions(LogType.YARN.getName(), "", param, results);
+        ParserResultSink parserResultSink = new ParserResultSink();
+        parserResultSink.register(OpenSearchWriter.getInstance());
+        List<String> list = parserResultSink.saveParserActions(
+                LogType.YARN.getName(), "", param, results);
 
         return new TaskResult(this.taskParam.getApp().getAppId(), new ArrayList<>(list));
     }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/IParserResultWriter.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/IParserResultWriter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 OPPO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oppo.cloud.parser.service.writer;
+
+import com.oppo.cloud.common.util.textparser.ParserAction;
+import com.oppo.cloud.parser.domain.job.ParserParam;
+
+/**
+ * ParserResultWriter interface
+ */
+public interface IParserResultWriter {
+
+    void write(String logType, String logPath, ParserParam param, ParserAction parserAction);
+
+}

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/LogWriter.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/LogWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 OPPO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oppo.cloud.parser.service.writer;
+
+import com.oppo.cloud.common.util.textparser.ParserAction;
+import com.oppo.cloud.parser.domain.job.ParserParam;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * a writer to log parser results, now just for testing
+ */
+@Slf4j
+public class LogWriter implements IParserResultWriter {
+
+    private List<ParserAction> parserActionList;
+
+    public LogWriter() {
+        this.parserActionList = new ArrayList<>();
+    }
+
+    @Override
+    public void write(String logType, String logPath, ParserParam param, ParserAction parserAction) {
+        log.info("Parsed results for logType {}," +
+                "logPath {}, param {}, parserAction {}",
+                logType, logPath, param, parserAction);
+        parserActionList.add(parserAction);
+    }
+
+    public List<ParserAction> getParserActionList() {
+        return parserActionList;
+    }
+}

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/OpenSearchWriter.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/OpenSearchWriter.java
@@ -58,7 +58,7 @@ import java.util.*;
  * OpenSearch writer
  */
 @Slf4j
-public class OpenSearchWriter {
+public class OpenSearchWriter implements IParserResultWriter {
 
     public RestHighLevelClient client;
 
@@ -90,28 +90,10 @@ public class OpenSearchWriter {
     }
 
     /**
-     * Save matching results
-     */
-    public List<String> saveParserActions(String logType, String logPath, ParserParam param, Map<String, ParserAction> results) {
-        List<String> categories = new ArrayList<>();
-        results.forEach((k, v) -> {
-            List<ParserAction> list = ParserActionUtil.getLeafAction(v, true);
-            if (list.size() == 0) {
-                log.error("getLeafAction:{},{}", k, v);
-                list.add(v);
-            }
-            for (ParserAction parserAction : list) {
-                categories.add(parserAction.getCategory());
-                writeToOpenSearch(logType, logPath, param, parserAction);
-            }
-        });
-        return categories;
-    }
-
-    /**
      * Write matching results to OpenSearch
      */
-    public void writeToOpenSearch(String logType, String logPath, ParserParam param, ParserAction parserAction) {
+    @Override
+    public void write(String logType, String logPath, ParserParam param, ParserAction parserAction) {
         if (parserAction.getParserResults() == null) {
             return;
         }

--- a/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/ParserResultSink.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/service/writer/ParserResultSink.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 OPPO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oppo.cloud.parser.service.writer;
+
+import com.oppo.cloud.common.util.textparser.ParserAction;
+import com.oppo.cloud.common.util.textparser.ParserActionUtil;
+import com.oppo.cloud.parser.domain.job.ParserParam;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A collection of writers, responsible for calling multiple writers
+ * to write parser results to different locations.
+ */
+@Slf4j
+public class ParserResultSink {
+
+    List<IParserResultWriter> writers;
+    public ParserResultSink() {
+        this.writers = new ArrayList<>();
+    }
+
+    public void register(IParserResultWriter writer) {
+        this.writers.add(writer);
+    }
+
+    /**
+     * Save matching results
+     */
+    public List<String> saveParserActions(String logType, String logPath, ParserParam param, Map<String, ParserAction> results) {
+        List<String> categories = new ArrayList<>();
+        results.forEach((k, v) -> {
+            List<ParserAction> list = ParserActionUtil.getLeafAction(v, true);
+            if (list.size() == 0) {
+                log.error("getLeafAction:{},{}", k, v);
+                list.add(v);
+            }
+            for (ParserAction parserAction : list) {
+                categories.add(parserAction.getCategory());
+                // write parsed data by all writers registered.
+                for (IParserResultWriter writer : writers) {
+                    writer.write(logType, logPath, param, parserAction);
+                }
+            }
+        });
+        return categories;
+    }
+
+}

--- a/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/ParserTestUtil.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/ParserTestUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 OPPO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oppo.cloud.parser.service.job.parser;
+
+import com.oppo.cloud.parser.service.writer.LogWriter;
+import com.oppo.cloud.parser.service.writer.ParserResultSink;
+
+public class ParserTestUtil {
+    public static ParserResultSink getLogSink() {
+        ParserResultSink parserResultSink = new ParserResultSink();
+        parserResultSink.register(new LogWriter());
+        return parserResultSink;
+    }
+}

--- a/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/SchedulerLogParserTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/SchedulerLogParserTest.java
@@ -42,7 +42,7 @@ class SchedulerLogParserTest {
                 logRecord.getApps().get(0), logPathMap.get(LogType.SCHEDULER.getName()));
         List<ParserAction> actions = DiagnosisConfig.getInstance().getActions(LogType.SPARK_EXECUTOR.getName());
 
-        SchedulerLogParser schedulerLogParser = new SchedulerLogParser(param, actions);
+        SchedulerLogParser schedulerLogParser = new SchedulerLogParser(param, actions, ParserTestUtil.getLogSink());
 
         CommonResult commonResult = schedulerLogParser.run();
         System.out.println(commonResult);

--- a/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParserTest.java
+++ b/task-parser/src/test/java/com/oppo/cloud/parser/service/job/parser/SparkExecutorLogParserTest.java
@@ -55,7 +55,7 @@ class SparkExecutorLogParserTest extends ResourcePreparer {
                 SpringBeanUtil.getBean(ThreadPoolConfig.PARSER_THREAD_POOL);
         List<String> jvmTypeList = (List<String>) SpringBeanUtil.getBean(CustomConfig.GC_CONFIG);
         List<ParserAction> actions = DiagnosisConfig.getInstance().getActions(LogType.SPARK_DRIVER.getName());
-        SparkExecutorLogParser parser = new SparkExecutorLogParser(param, actions, parserThreadPool, jvmTypeList);
+        SparkExecutorLogParser parser = new SparkExecutorLogParser(param, actions, ParserTestUtil.getLogSink(), parserThreadPool, jvmTypeList);
         CommonResult commonResult = parser.run();
         List<SparkExecutorLogParserResult> results = (List<SparkExecutorLogParserResult>) commonResult.getResult();
         Assertions.assertTrue(results.size() == 1);


### PR DESCRIPTION
Introducing `ParserResultsSink` , which holds multiple writers. Parsers can write results to multiple locations by calling `saveParserActions`.

cc @zhongdongbo 