### PR TITLE
fix: adapt hadoop json/xml response content format and add value_variable properties support

### DIFF
--- a/task-flink/src/main/java/com/oppo/cloud/flink/domain/Properties.java
+++ b/task-flink/src/main/java/com/oppo/cloud/flink/domain/Properties.java
@@ -16,6 +16,10 @@
 
 package com.oppo.cloud.flink.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.Data;
 
 @Data
@@ -23,4 +27,67 @@ public class Properties {
 
     private String key;
     private String value;
+
+    public String getFinalValue(List<Properties> properties) {
+        String variableName = findVariableName(value);
+        if (variableName == null) {
+            return value;
+        }
+
+        for (Properties property : properties) {
+            if (!property.key.equals(this.key)) {
+                continue;
+            }
+
+            String variableValue = property.getFinalValue(properties);
+            return value.replace("${" + variableName + "}", variableValue);
+        }
+
+        return value;
+    }
+
+    private String findVariableName(String originalValue) {
+        Pattern VAR_PATTERN = Pattern.compile("\\$\\{(\\w+)}"); //变量格式${var_name}
+        Matcher matcher = VAR_PATTERN.matcher(originalValue);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        return null;
+    }
+
+    public static void main(String[] args) {
+        List<Properties> properties = new ArrayList<>();
+        Properties prop_1 = new Properties();
+        prop_1.key = "yarn.timeline-service.webapp.address";
+        prop_1.value = "${yarn.timeline-service.hostname}:8188";
+
+        Properties prop_2 = new Properties();
+        prop_2.key = "dfs.webhdfs.user.provider.user.pattern";
+        prop_2.value = "^[A-Za-z_][A-Za-z0-9._-]*[$]?$";
+
+        Properties prop_3 = new Properties();
+        prop_3.key = "yarn.scheduler.configuration.fs.path";
+        prop_3.value = "file://${hadoop.tmp.dir}/yarn/system/schedconf";
+
+        Properties prop_4 = new Properties();
+        prop_4.key = "yarn.timeline-service.reader.webapp.address";
+        prop_4.value = "${yarn.timeline-service.webapp.address}";
+
+        Properties prop_5 = new Properties();
+        prop_5.key = "yarn.timeline-service.hostname";
+        prop_5.value = "127.0.0.1";
+
+        properties.add(prop_1);
+        properties.add(prop_2);
+        properties.add(prop_3);
+        properties.add(prop_4);
+        properties.add(prop_5);
+
+        assert "127.0.0.1:8188".equals(prop_1.getFinalValue(properties));
+        assert "127.0.0.1:8188".equals(prop_4.getFinalValue(properties));
+        assert "file://${hadoop.tmp.dir}/yarn/system/schedconf".equals(prop_3.getFinalValue(properties));
+        assert "^[A-Za-z_][A-Za-z0-9._-]*[$]?$".equals(prop_2.getFinalValue(properties));
+        assert "^127.0.0.1".equals(prop_5.getFinalValue(properties));
+    }
 }

--- a/task-metadata/src/main/java/com/oppo/cloud/meta/domain/Properties.java
+++ b/task-metadata/src/main/java/com/oppo/cloud/meta/domain/Properties.java
@@ -16,6 +16,10 @@
 
 package com.oppo.cloud.meta.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.Data;
 
 @Data
@@ -23,4 +27,67 @@ public class Properties {
 
     private String key;
     private String value;
+
+    public String getFinalValue(List<Properties> properties) {
+        String variableName = findVariableName(value);
+        if (variableName == null) {
+            return value;
+        }
+
+        for (Properties property : properties) {
+            if (!property.key.equals(this.key)) {
+                continue;
+            }
+
+            String variableValue = property.getFinalValue(properties);
+            return value.replace("${" + variableName + "}", variableValue);
+        }
+
+        return value;
+    }
+
+    private String findVariableName(String originalValue) {
+        Pattern VAR_PATTERN = Pattern.compile("\\$\\{(\\w+)}"); //变量格式${var_name}
+        Matcher matcher = VAR_PATTERN.matcher(originalValue);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        return null;
+    }
+
+    public static void main(String[] args) {
+        List<Properties> properties = new ArrayList<>();
+        Properties prop_1 = new Properties();
+        prop_1.key = "yarn.timeline-service.webapp.address";
+        prop_1.value = "${yarn.timeline-service.hostname}:8188";
+
+        Properties prop_2 = new Properties();
+        prop_2.key = "dfs.webhdfs.user.provider.user.pattern";
+        prop_2.value = "^[A-Za-z_][A-Za-z0-9._-]*[$]?$";
+
+        Properties prop_3 = new Properties();
+        prop_3.key = "yarn.scheduler.configuration.fs.path";
+        prop_3.value = "file://${hadoop.tmp.dir}/yarn/system/schedconf";
+
+        Properties prop_4 = new Properties();
+        prop_4.key = "yarn.timeline-service.reader.webapp.address";
+        prop_4.value = "${yarn.timeline-service.webapp.address}";
+
+        Properties prop_5 = new Properties();
+        prop_5.key = "yarn.timeline-service.hostname";
+        prop_5.value = "127.0.0.1";
+
+        properties.add(prop_1);
+        properties.add(prop_2);
+        properties.add(prop_3);
+        properties.add(prop_4);
+        properties.add(prop_5);
+
+        assert "127.0.0.1:8188".equals(prop_1.getFinalValue(properties));
+        assert "127.0.0.1:8188".equals(prop_4.getFinalValue(properties));
+        assert "file://${hadoop.tmp.dir}/yarn/system/schedconf".equals(prop_3.getFinalValue(properties));
+        assert "^[A-Za-z_][A-Za-z0-9._-]*[$]?$".equals(prop_2.getFinalValue(properties));
+        assert "^127.0.0.1".equals(prop_5.getFinalValue(properties));
+    }
 }

--- a/task-metadata/src/main/java/com/oppo/cloud/meta/service/impl/ClusterConfigServiceImpl.java
+++ b/task-metadata/src/main/java/com/oppo/cloud/meta/service/impl/ClusterConfigServiceImpl.java
@@ -30,7 +30,6 @@ import com.oppo.cloud.meta.service.IClusterConfigService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -41,7 +40,6 @@ import org.w3c.dom.NodeList;
 import javax.annotation.Resource;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -200,7 +198,7 @@ public class ClusterConfigServiceImpl implements IClusterConfigService {
         if (yarnConfProperties != null && yarnConfProperties.getProperties() != null) {
             for (Properties properties : yarnConfProperties.getProperties()) {
                 String key = properties.getKey();
-                String value = properties.getValue();
+                String value = properties.getFinalValue(yarnConfProperties.getProperties());
                 if (YARN_REMOTE_APP_LOG_DIR.equals(key)) {
                     log.info("yarnConfProperties key: {}, value: {}", YARN_REMOTE_APP_LOG_DIR, value);
                     remoteDir = value;


### PR DESCRIPTION
1、apply json/xml respone to task-flink module
2、add value_variable properties support 

see detail as follow conf example :
![image](https://github.com/cubefs/compass/assets/18046946/49ec8131-40db-4384-a060-fa6f44bd59e3)