### PR TITLE
fix: fix mysql access denied error(#214)

### DIFF
--- a/docker/playground/README.md
+++ b/docker/playground/README.md
@@ -91,7 +91,7 @@ Note: You can install virtulbox to start docker compose, which requires about 10
     
         
     # start dolphinscheduler services
-    docker compose --profile dolphinscheduler up -d
+    docker-compose --profile dolphinscheduler up -d --build
     ```
 
 Run dolphinscheduler example, please refer to [dolphinscheduler example document](../../document/manual/ds_example.md)


### PR DESCRIPTION
As I found that only add "--build" to that instruction, the `compass-playground-dolphinscheduler.Dockerfile` can be used and then the MySQL inside the dolphinscheduler docker can be work well.