### PR TITLE
[#224] fix: addressing Negative Values Arising from Wasted CPU Comput…

### DIFF
--- a/task-parser/src/main/java/com/oppo/cloud/parser/utils/ReplaySparkEventLogs.java
+++ b/task-parser/src/main/java/com/oppo/cloud/parser/utils/ReplaySparkEventLogs.java
@@ -112,12 +112,22 @@ public class ReplaySparkEventLogs {
             case "SparkListenerApplicationStart":
                 SparkListenerApplicationStart sparkListenerApplicationStart = objectMapper.readValue(line,
                         SparkListenerApplicationStart.class);
-                this.application.setAppStartTimestamp(sparkListenerApplicationStart.getTime());
+                Long appStartTimestamp = this.application.getAppStartTimestamp();
+                if (appStartTimestamp != null && appStartTimestamp < sparkListenerApplicationStart.getTime()) {
+                    this.application.setAppStartTimestamp(appStartTimestamp);
+                }else {
+                    this.application.setAppStartTimestamp(sparkListenerApplicationStart.getTime());
+                }
                 break;
             case "SparkListenerApplicationEnd":
                 SparkListenerApplicationEnd sparkListenerApplicationEnd = objectMapper.readValue(line,
                         SparkListenerApplicationEnd.class);
-                this.application.setAppEndTimestamp(sparkListenerApplicationEnd.getTime());
+                Long appEndTimestamp = this.application.getAppEndTimestamp();
+                if (appEndTimestamp != null && appEndTimestamp > sparkListenerApplicationEnd.getTime()){
+                    this.application.setAppEndTimestamp(appEndTimestamp);
+                }else {
+                    this.application.setAppEndTimestamp(sparkListenerApplicationEnd.getTime());
+                }
                 break;
             case "SparkListenerBlockManagerAdded":
                 SparkListenerBlockManagerAdded sparkListenerBlockManagerAdded = objectMapper.readValue(line,


### PR DESCRIPTION
When parsing event logs, in cases where there are multiple attempts for a job, calculate the total duration of the job by using the earliest start time and the latest end time.